### PR TITLE
Make emptyLineCircleView centered and filledLineCircleView full constrained in PKCircleProgressView

### DIFF
--- a/Pod/Classes/PKCircleProgressView.m
+++ b/Pod/Classes/PKCircleProgressView.m
@@ -170,8 +170,8 @@ static PKCircleProgressView *CommonInit(PKCircleProgressView *self) {
 
 - (NSArray *)createCircleConstraints {
     NSMutableArray *constraints = [NSMutableArray array];
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsForWrappedSubview:self.emptyLineCircleView
-                                                                           withInsets:UIEdgeInsetsZero]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsForCenterView:self.emptyLineCircleView
+                                                                         withView:self]];
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsForWrappedSubview:self.filledLineCircleView
                                                                            withInsets:UIEdgeInsetsZero]];
     return constraints;


### PR DESCRIPTION
This is to fix an issue in https://github.com/PavelKatunin/DownloadButton/pull/26 as the emptyLineCircleView should be smaller than the filledLineCircleView.