### PR TITLE
Make Podfile compatible with Pods 1.0+

### DIFF
--- a/Example/DownloadButton.xcodeproj/project.pbxproj
+++ b/Example/DownloadButton.xcodeproj/project.pbxproj
@@ -223,12 +223,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "DownloadButton_Example" */;
 			buildPhases = (
-				B6CB29F0601722BB49BDEC13 /* Check Pods Manifest.lock */,
+				B6CB29F0601722BB49BDEC13 /* [CP] Check Pods Manifest.lock */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				A8A60B7C722A4F3865CC307C /* Embed Pods Frameworks */,
-				0ED25D569A6B2A0C12275546 /* Copy Pods Resources */,
+				A8A60B7C722A4F3865CC307C /* [CP] Embed Pods Frameworks */,
+				0ED25D569A6B2A0C12275546 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -243,12 +243,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "DownloadButton_Tests" */;
 			buildPhases = (
-				880CE9AE0BA01C6F49694E1E /* Check Pods Manifest.lock */,
+				880CE9AE0BA01C6F49694E1E /* [CP] Check Pods Manifest.lock */,
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
-				3C938EED788B4901D3879902 /* Embed Pods Frameworks */,
-				BE692D0B5CCEF708D9C8DB8F /* Copy Pods Resources */,
+				3C938EED788B4901D3879902 /* [CP] Embed Pods Frameworks */,
+				BE692D0B5CCEF708D9C8DB8F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -317,14 +317,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0ED25D569A6B2A0C12275546 /* Copy Pods Resources */ = {
+		0ED25D569A6B2A0C12275546 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -332,74 +332,94 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-DownloadButton_Example/Pods-DownloadButton_Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3C938EED788B4901D3879902 /* Embed Pods Frameworks */ = {
+		3C938EED788B4901D3879902 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-DownloadButton_Tests/Pods-DownloadButton_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/DownloadButton/DownloadButton.framework",
+				"${BUILT_PRODUCTS_DIR}/Expecta/Expecta.framework",
+				"${BUILT_PRODUCTS_DIR}/Expecta+Snapshots/Expecta_Snapshots.framework",
+				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
+				"${BUILT_PRODUCTS_DIR}/Specta/Specta.framework",
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DownloadButton.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta_Snapshots.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Specta.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-DownloadButton_Tests/Pods-DownloadButton_Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		880CE9AE0BA01C6F49694E1E /* Check Pods Manifest.lock */ = {
+		880CE9AE0BA01C6F49694E1E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-DownloadButton_Tests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A8A60B7C722A4F3865CC307C /* Embed Pods Frameworks */ = {
+		A8A60B7C722A4F3865CC307C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-DownloadButton_Example/Pods-DownloadButton_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/DownloadButton/DownloadButton.framework",
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DownloadButton.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-DownloadButton_Example/Pods-DownloadButton_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B6CB29F0601722BB49BDEC13 /* Check Pods Manifest.lock */ = {
+		B6CB29F0601722BB49BDEC13 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-DownloadButton_Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BE692D0B5CCEF708D9C8DB8F /* Copy Pods Resources */ = {
+		BE692D0B5CCEF708D9C8DB8F /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -559,7 +579,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DownloadButton/DownloadButton-Prefix.pch";
 				INFOPLIST_FILE = "DownloadButton/DownloadButton-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -575,7 +595,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DownloadButton/DownloadButton-Prefix.pch";
 				INFOPLIST_FILE = "DownloadButton/DownloadButton-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,15 +1,21 @@
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
+platform :ios, '8.0'
 
-target 'DownloadButton_Example', :exclusive => true do
+def shared_pods
   pod "DownloadButton", :path => "../"
 end
 
-target 'DownloadButton_Tests', :exclusive => true do
-  pod "DownloadButton", :path => "../"
+target 'DownloadButton_Example' do
+  shared_pods
+end
+
+target 'DownloadButton_Tests' do
+  shared_pods
 
   pod 'Specta'
   pod 'Expecta'
   pod 'FBSnapshotTestCase'
   pod 'Expecta+Snapshots'
 end
+


### PR DESCRIPTION
The Example app is not buildable out of the box, [as Cocoapods removed support for `:exclusive => true` as of 1.0](http://blog.cocoapods.org/CocoaPods-1.0-Migration-Guide/) (bullet point # 5).

I also bumped up the minimum deployment version for the Example app to 8.0, as doing a `pod install` was throwing some weird warnings about one target having an arbitrary deployment version of 7.0 while the test target may have automatically been set to 8.0 via another Pod dependency.

Either way, I hope this helps you and/or somebody else!