### PR TITLE
Update button background

### DIFF
--- a/DownloadButton.podspec
+++ b/DownloadButton.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "DownloadButton"
-  s.version          = "0.1.0"
+  s.version          = "0.1.1"
   s.summary          = "Customizable Appstore style download button."
   s.description      = <<-DESC
                        Customizable Appstore style download button, and other UI components

--- a/Pod/Classes/PKDownloadButton.m
+++ b/Pod/Classes/PKDownloadButton.m
@@ -39,6 +39,7 @@ static PKDownloadButton *CommonInit(PKDownloadButton *self) {
         [self addConstraints:[self createConstraints]];
         
         self.state = kPKDownloadButtonState_StartDownload;
+        self.backgroundColor = [UIColor clearColor];
     }
     return self;
 }


### PR DESCRIPTION
DownloadButton's view background is currently white.  Which looks great when the rest of the background on the screen is white.  If you change the background to green though, it doesn't look so good:
![beforechangescreenshot1](https://user-images.githubusercontent.com/577437/30503511-8847e2d2-9a38-11e7-9b90-d941cd5f0e48.jpg)
![beforechangescreenshot2](https://user-images.githubusercontent.com/577437/30503512-8848a80c-9a38-11e7-92b6-40859baaa446.jpg)
So I made a change (and bumped the pod version) to change the background color of the DownloadButton view to clear.  On different colored screens, I hope this change looks a lot nicer!
![afterchangescreenshot1](https://user-images.githubusercontent.com/577437/30503509-8844a6a8-9a38-11e7-8700-8b5b8586c596.jpg)
![afterchangescreenshot2](https://user-images.githubusercontent.com/577437/30503510-8847a60a-9a38-11e7-9994-533ae4162e83.jpg)
![afterchangescreenshot3](https://user-images.githubusercontent.com/577437/30503648-0c7d99ac-9a39-11e7-96aa-91acba26ecbe.jpg)

You (Pavel) would need to actually push out this update to Cocoapods, though.